### PR TITLE
add vm_cluster_ocid as output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ resource "azapi_resource" "odaa_vm_cluster" {
   name                      = var.cluster_name
   parent_id                 = var.resource_group_id
   schema_validation_enabled = false
+  response_export_values = ["properties.ocid"]
 
   timeouts {
     create = "24h"

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "resource_id" {
   description = "Resource ID of the ODAA VM Cluster"
   value       = azapi_resource.odaa_vm_cluster.id
 }
+
+output "vm_cluster_ocid" {
+  value = azapi_resource.odaa_vm_cluster.output.properties.ocid
+}


### PR DESCRIPTION
## Description
Add OCID of VM Cluster as output for further automation in OCI (e.g. DB Home creation)
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
